### PR TITLE
add modifier order to style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -2939,18 +2939,18 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
-* <a id='modifier-order'></a>(<a href='#modifier-order'>link</a>) **Use consistent ordering for modifiers.** `public` comes before `final`. [![SwiftFormat: modifierOrder](https://img.shields.io/badge/SwiftFormat-modifierOrder-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#modifierOrder)
+* <a id='modifier-order'></a>(<a href='#modifier-order'>link</a>) **Use consistent ordering for modifiers.** Access modifiers like `public` and `private` come before other modifiers like `final` or `static`. [![SwiftFormat: modifierOrder](https://img.shields.io/badge/SwiftFormat-modifierOrder-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#modifierOrder)
 
   <details>
 
   ```swift
   // WRONG
-  final public Spaceship {}
+  final public class Spaceship {}
   ```
 
   ```swift
   // RIGHT
-  public final Spaceship {}
+  public final class Spaceship {}
   ```
 
   </details>

--- a/README.md
+++ b/README.md
@@ -2939,6 +2939,22 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   </details>
 
+* <a id='modifier-order'></a>(<a href='#modifier-order'>link</a>) **Use consistent ordering for modifiers.** `public` comes before `final`. [![SwiftFormat: modifierOrder](https://img.shields.io/badge/SwiftFormat-modifierOrder-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#modifierOrder)
+
+  <details>
+
+  ```swift
+  // WRONG
+  final public Spaceship {}
+  ```
+
+  ```swift
+  // RIGHT
+  public final Spaceship {}
+  ```
+
+  </details>
+
 * <a id='limit-access-control'></a>(<a href='#limit-access-control'>link</a>) **Access control should be at the strictest level possible.** Prefer `public` to `open` and `private` to `fileprivate` unless you need that behavior. [![SwiftFormat: redundantFileprivate](https://img.shields.io/badge/SwiftFormat-redundantFileprivate-7B0051.svg)](https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#redundantFileprivate)
 
   <details>

--- a/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+++ b/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
@@ -50,6 +50,9 @@
 --semicolons never # semicolons
 --doc-comments preserve # docComments
 
+# Customized default modifier order to put `override` after access control
+--modifier-order private,fileprivate,internal,package,public,open,private(set),fileprivate(set),internal(set),package(set),public(set),open(set),override,final,dynamic,optional,required,convenience,indirect,isolated,nonisolated,nonisolated(unsafe),lazy,weak,unowned,unowned(safe),unowned(unsafe),static,class,borrowing,consuming,mutating,nonmutating,prefix,infix,postfix,async # modifierOrder
+
 # We recommend a max width of 100 but _strictly enforce_ a max width of 130
 --max-width 130 # wrap
 


### PR DESCRIPTION
#### Summary

Adopting the Modifier Order rule, which dictates the order of access control modifiers and `final` in class declarations. 

#### Reasoning

I find that I spend a lot of time thinking about whether to write `final public` or `public final` on classes. Let's choose an ordering and never think about it again. 